### PR TITLE
Updating action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,9 +22,9 @@ jobs:
         working-directory: ./src
 
     steps:
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
     - name: Setup .NET
-      uses: actions/setup-dotnet@499789684c9a0d41c9b3f0d66a785ba17b1d51ab
+      uses: actions/setup-dotnet@499789684c9a0d41c9b3f0d66a785ba17b1d51ab # v1.9.0
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,37 +3,30 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-name: Build and Run Unit Tests
+name: Build and Test
 on:
-  pull_request:
-    paths:
-      - 'src/**'
   push:
-    paths:
-      - 'src/**'
-    branches:
-      - main
+    branches: [ main ]
+  pull_request:
+
 jobs:
-  build-and-test:
-    name: Build and Run Unit Tests
-    runs-on: ubuntu-20.04
+  build-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
     defaults:
       run:
         working-directory: ./src
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-
-      - name: Prepare nuget.exe
-        uses: nuget/setup-nuget@04b0c2b8d1b97922f67eca497d7cf0bf17b8ffe1
-        with:
-          nuget-version: '5.x'
-
-      - name: Restore packages
-        run: nuget restore Ed-Fi-SDG.sln
-
-      - name: Compile
-        run: dotnet build Ed-Fi-SDG.sln
-
-      - name: Run unit tests
-        run: dotnet test Ed-Fi-SDG.sln
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build
+    - name: Run unit tests
+      run: dotnet test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    paths:
+      - 'src/**'
+  workflow_dispatch:
 
 jobs:
   build-test:
@@ -19,9 +22,9 @@ jobs:
         working-directory: ./src
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@499789684c9a0d41c9b3f0d66a785ba17b1d51ab
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies


### PR DESCRIPTION
Updating GitHub action to have a similar structure to other projects. 
The main difference from this change is that instead of using NuGet and MBuild tasks we use .net 6 to restore and compile. 
The job is running successfully on https://github.com/andonyns/Ed-Fi-SampleDataGenerator/actions/runs/1668238672 with the new structure.