### PR TITLE
Creating method to get relative path for windows and linux to avoid issues with GH Actions

### DIFF
--- a/src/EdFi.SampleDataGenerator.Core.UnitTests/DataGeneration/Coordination/GlobalDataGenerationCoordinatorTester.cs
+++ b/src/EdFi.SampleDataGenerator.Core.UnitTests/DataGeneration/Coordination/GlobalDataGenerationCoordinatorTester.cs
@@ -145,9 +145,9 @@ namespace EdFi.SampleDataGenerator.Core.UnitTests.DataGeneration.Coordination
                 Interchange.StudentGradebook
             };
 
-            var manifestPart1 = fileOutputService.GetManifest(".\\ManifestGlobalData-Part 1.xml").ToXml().ToString();
-            var manifestPart2 = fileOutputService.GetManifest(".\\ManifestGlobalData-Part 2.xml").ToXml().ToString();
-            var manifestPart3 = fileOutputService.GetManifest(".\\ManifestGlobalData-Part 3.xml").ToXml().ToString();
+            var manifestPart1 = fileOutputService.GetManifest(GetPath("ManifestGlobalData-Part 1.xml")).ToXml().ToString();
+            var manifestPart2 = fileOutputService.GetManifest(GetPath("ManifestGlobalData-Part 2.xml")).ToXml().ToString();
+            var manifestPart3 = fileOutputService.GetManifest(GetPath("ManifestGlobalData-Part 3.xml")).ToXml().ToString();
 
             foreach (var targetInterchange in targetInterchanges)
             {
@@ -158,41 +158,41 @@ namespace EdFi.SampleDataGenerator.Core.UnitTests.DataGeneration.Coordination
 
             fileOutputService.OutputFilePaths.Length.ShouldBe(30);
 
-            fileOutputService.GetOutput<InterchangeDescriptors>(".\\Descriptors-Part 1.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStandards>(".\\Standards-Part 1.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeEducationOrganization>(".\\EducationOrganization-Part 1.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeEducationOrgCalendar>(".\\EducationOrgCalendar-Part 1.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeMasterSchedule>(".\\MasterSchedule-Part 1.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStaffAssociation>(".\\StaffAssociation-Part 1.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStudentEnrollment>(".\\StudentEnrollment-Part 1.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeAssessmentMetadata>(".\\AssessmentMetadata-Part 1.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStudentCohort>(".\\StudentCohort-Part 1.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStudentGradebook>(".\\StudentGradebook-Part 1.xml").ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeDescriptors>(GetPath("Descriptors-Part 1.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStandards>(GetPath("Standards-Part 1.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeEducationOrganization>(GetPath("EducationOrganization-Part 1.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeEducationOrgCalendar>(GetPath("EducationOrgCalendar-Part 1.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeMasterSchedule>(GetPath("MasterSchedule-Part 1.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStaffAssociation>(GetPath("StaffAssociation-Part 1.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStudentEnrollment>(GetPath("StudentEnrollment-Part 1.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeAssessmentMetadata>(GetPath("AssessmentMetadata-Part 1.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStudentCohort>(GetPath("StudentCohort-Part 1.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStudentGradebook>(GetPath("StudentGradebook-Part 1.xml")).ShouldNotBeNull();
 
-            fileOutputService.GetOutput<InterchangeDescriptors>(".\\Descriptors-Part 2.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStandards>(".\\Standards-Part 2.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeEducationOrganization>(".\\EducationOrganization-Part 2.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeEducationOrgCalendar>(".\\EducationOrgCalendar-Part 2.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeMasterSchedule>(".\\MasterSchedule-Part 2.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStaffAssociation>(".\\StaffAssociation-Part 2.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStudentEnrollment>(".\\StudentEnrollment-Part 2.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeAssessmentMetadata>(".\\AssessmentMetadata-Part 2.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStudentCohort>(".\\StudentCohort-Part 2.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStudentGradebook>(".\\StudentGradebook-Part 2.xml").ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeDescriptors>(GetPath("Descriptors-Part 2.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStandards>(GetPath("Standards-Part 2.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeEducationOrganization>(GetPath("EducationOrganization-Part 2.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeEducationOrgCalendar>(GetPath("EducationOrgCalendar-Part 2.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeMasterSchedule>(GetPath("MasterSchedule-Part 2.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStaffAssociation>(GetPath("StaffAssociation-Part 2.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStudentEnrollment>(GetPath("StudentEnrollment-Part 2.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeAssessmentMetadata>(GetPath("AssessmentMetadata-Part 2.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStudentCohort>(GetPath("StudentCohort-Part 2.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStudentGradebook>(GetPath("StudentGradebook-Part 2.xml")).ShouldNotBeNull();
 
-            fileOutputService.GetOutput<InterchangeDescriptors>(".\\Descriptors-Part 3.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStandards>(".\\Standards-Part 3.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeEducationOrganization>(".\\EducationOrganization-Part 3.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeEducationOrgCalendar>(".\\EducationOrgCalendar-Part 3.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeMasterSchedule>(".\\MasterSchedule-Part 3.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStaffAssociation>(".\\StaffAssociation-Part 3.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStudentEnrollment>(".\\StudentEnrollment-Part 3.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeAssessmentMetadata>(".\\AssessmentMetadata-Part 3.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStudentCohort>(".\\StudentCohort-Part 3.xml").ShouldNotBeNull();
-            fileOutputService.GetOutput<InterchangeStudentGradebook>(".\\StudentGradebook-Part 3.xml").ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeDescriptors>(GetPath("Descriptors-Part 3.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStandards>(GetPath("Standards-Part 3.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeEducationOrganization>(GetPath("EducationOrganization-Part 3.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeEducationOrgCalendar>(GetPath("EducationOrgCalendar-Part 3.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeMasterSchedule>(GetPath("MasterSchedule-Part 3.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStaffAssociation>(GetPath("StaffAssociation-Part 3.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStudentEnrollment>(GetPath("StudentEnrollment-Part 3.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeAssessmentMetadata>(GetPath("AssessmentMetadata-Part 3.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStudentCohort>(GetPath("StudentCohort-Part 3.xml")).ShouldNotBeNull();
+            fileOutputService.GetOutput<InterchangeStudentGradebook>(GetPath("StudentGradebook-Part 3.xml")).ShouldNotBeNull();
         }
 
-        private static string ExpectedManifestEntry(Interchange interchange, string dataPeriodName) => 
+        private static string ExpectedManifestEntry(Interchange interchange, string dataPeriodName) =>
 $@"  <Interchange>
     <Filename>{interchange.Name}-{dataPeriodName}.xml</Filename>
     <Type>{interchange.Name}</Type>

--- a/src/EdFi.SampleDataGenerator.Core.UnitTests/DataGeneration/GeneratorTestBase.cs
+++ b/src/EdFi.SampleDataGenerator.Core.UnitTests/DataGeneration/GeneratorTestBase.cs
@@ -45,7 +45,7 @@ namespace EdFi.SampleDataGenerator.Core.UnitTests.DataGeneration
             var configReader = new GlobalDataGeneratorConfigReader();
 
             var config = configReader.Read(sampleDataGeneratorConfig);
-            config.GraduationPlans = schoolProfiles.SelectMany(sp => 
+            config.GraduationPlans = schoolProfiles.SelectMany(sp =>
                 sp.GradeProfiles.Select(gp => new GraduationPlan
                 {
                     EducationOrganizationReference = sp.GetEducationOrganizationReference(),
@@ -101,7 +101,7 @@ namespace EdFi.SampleDataGenerator.Core.UnitTests.DataGeneration
                 }
             };
             return result;
-        } 
+        }
 
         private static CohortData GetCohortData()
         {
@@ -162,14 +162,14 @@ namespace EdFi.SampleDataGenerator.Core.UnitTests.DataGeneration
             {
                 BatchSize = null,
                 DataFilePath = Path.Combine(AssemblyDirectory, "DataFiles"),
-                OutputPath = ".\\",
+                OutputPath = GetPath(""),
                 SeedFilePath = null,
                 OutputMode = OutputMode.Standard,
                 TimeConfig = TestTimeConfig.Default,
                 CreatePerformanceFile = true,
                 DistrictProfiles = new IDistrictProfile[]
                 {
-                    TestDistrictProfile.Default, 
+                    TestDistrictProfile.Default,
                 },
                 StudentProfiles = new IStudentProfile[]
                 {
@@ -215,7 +215,10 @@ namespace EdFi.SampleDataGenerator.Core.UnitTests.DataGeneration
         {
             return TestGradeProfile.Default;
         }
-        
+
+        public static string GetPath(string FileName) {
+                return $".{Path.DirectorySeparatorChar}{FileName}";
+        }
 
         public static NameFileData GetNameFileData()
         {


### PR DESCRIPTION
When running GitHub Actions, since the images run in Ubuntu, it generates relative paths with '/', and the tests where executing the validation by verifying the paths with '\'. This PR creates a method to get the correct slash for each OS